### PR TITLE
[Muffin] Header Input Container 기능 구현 진행중 

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
-import { GlobalStyles } from '@mui/material';
-import CssBaseline from '@mui/material/CssBaseline';
+import { CssBaseline } from '@mui/material';
+import GlobalStyles from '@mui/material/GlobalStyles';
 import { ThemeProvider } from '@mui/material/styles';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 
@@ -15,6 +15,7 @@ function MyGlobalStyles() {
         body: {
           backgroundColor: color.bgColor,
           color: color.grey1,
+          height: '100vh',
         },
       }}
     />

--- a/src/common/keyframes.tsx
+++ b/src/common/keyframes.tsx
@@ -1,0 +1,21 @@
+import { keyframes } from '@emotion/react';
+
+export const fadeIn = keyframes`
+  from {
+    transform: translateY(-100%);
+  }
+
+  to {
+    transform: translateY(0)
+  }
+`;
+
+export const fadeOut = keyframes`
+  from {
+    transform: translateY(0);
+  }
+
+  to {
+    transform: translateY(-100%);
+  }
+`;

--- a/src/components/Header/BigSearchBar.tsx
+++ b/src/components/Header/BigSearchBar.tsx
@@ -1,6 +1,7 @@
 import SearchIcon from '@mui/icons-material/Search';
 import { Box, Divider, Typography } from '@mui/material';
 
+import { fadeIn } from '@common/keyframes';
 import FlexBox from '@components/FlexBox';
 import color from '@constants/color';
 import fontSize from '@constants/fontSize';
@@ -18,6 +19,7 @@ export default function BigSearchBar() {
         borderColor: color.grey4,
         borderRadius: '3.75rem',
         position: 'absolute',
+        animation: `${fadeIn} .3s ease`,
       }}
       ai="center"
     >

--- a/src/components/Header/Category.tsx
+++ b/src/components/Header/Category.tsx
@@ -1,6 +1,7 @@
 import { Link, Breadcrumbs } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
+import { fadeIn } from '@common/keyframes';
 import color from '@constants/color';
 
 const StyledBreadcrumb = styled(Link)({
@@ -15,7 +16,11 @@ const StyledBreadcrumb = styled(Link)({
 
 export default function Category() {
   return (
-    <Breadcrumbs separator="" aria-label="headerCategory">
+    <Breadcrumbs
+      separator=""
+      aria-label="headerCategory"
+      sx={{ animation: `${fadeIn} .3s ease` }}
+    >
       <StyledBreadcrumb>숙소</StyledBreadcrumb>
       <StyledBreadcrumb>체험</StyledBreadcrumb>
       <StyledBreadcrumb>온라인 체험</StyledBreadcrumb>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,5 +1,5 @@
 import { Container, Box } from '@mui/material';
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 
 import FlexBox from '@components/FlexBox';
 import BigSearchBar from '@components/Header/BigSearchBar';
@@ -10,18 +10,45 @@ import UserInfo from '@components/Header/UserInfo';
 import color from '@constants/color';
 
 export default function Header() {
-  const [view, setView] = useState(false);
+  const [isFocus, setIsFocus] = useState(false);
 
   const handleSearchBarOnClick = () => {
-    setView(!view);
+    setIsFocus(!isFocus);
   };
+
+  const closeBigSearchBar = useCallback(
+    (e: MouseEvent) => {
+      if (isFocus) {
+        // e.target이 헤더 이외일때 setIsFocus(false)
+        const target = e.target as HTMLInputElement;
+        if (target.tagName === 'BODY') setIsFocus(false);
+      }
+    },
+    [isFocus],
+  );
+
+  useEffect(() => {
+    if (isFocus) {
+      document.body.style.backgroundColor = color.grey4;
+    } else {
+      document.body.style.backgroundColor = color.white;
+    }
+  }, [isFocus]);
+
+  useEffect(() => {
+    document.body.addEventListener('click', closeBigSearchBar);
+
+    return () => {
+      document.body.removeEventListener('click', closeBigSearchBar);
+    };
+  }, [closeBigSearchBar]);
 
   return (
     <FlexBox
       component="header"
       sx={{
         backgroundColor: color.white,
-        height: view ? '11.875rem' : '5.875rem',
+        height: isFocus ? '11.875rem' : '5.875rem',
         padding: '1.5rem 2rem',
         transition: 'height .2s ease',
       }}
@@ -29,7 +56,7 @@ export default function Header() {
     >
       <Logo />
       <Container maxWidth="sm">
-        {view ? (
+        {isFocus ? (
           <Box>
             <Category />
             <BigSearchBar />


### PR DESCRIPTION
resolve #4 

1. height 값으로 body에 onclick eventlistener를 달았을시 영역 문제 → GlobalStyles적용

2. header isFocus 상태시 body 영역 색상 변경 → useEffect로 제어 하긴 했는데 body에 bg색상을 인라인으로 줘서 다른 방법으로 수정필요

3. Header 컴포넌트가 리렌더링될때 맨처음 useEffect에 closeBigSearchBar 함수 이벤트 바디에 달기 → 헤더 이외 영역을 클릭 시 헤더 isFocus state 값 false로 변경시켜 제어해주기 위해

4. closeBigSearchBar 함수를 useCallback으로 감싼 이유 ? 
- Header 컴포넌트가 매 실행마다 closeBigSearchBar 함수를 계속 생성하여 경고 창을 보여주고 있어서, useCallback으로 closeBigSearchBar함수를 감싸 react내에서 내부적으로 Header 컴포넌트가 실행될때마다 해당 함수를 재생성하지 않고 캐시처럼 동일한 메모리내에 함수를 저장하여 관리해줌


5. Search Bar mount, unmount시 transition 제어 ([(https://velog.io/@dosilv/React-mountunmount-%EC%8B%9C-%EC%95%A0%EB%8B%88%EB%A9%94%EC%9D%B4%EC%85%98-%EC%A3%BC%EA%B8%B0)](https://velog.io/@dosilv/React-mountunmount-%EC%8B%9C-%EC%95%A0%EB%8B%88%EB%A9%94%EC%9D%B4%EC%85%98-%EC%A3%BC%EA%B8%B0), [https://stackoverflow.com/questions/40064249/react-animate-mount-and-unmount-of-a-single-component](https://stackoverflow.com/questions/40064249/react-animate-mount-and-unmount-of-a-single-component))
-> 참고하여 개발 진행중, 우선 해당 애니메이션의 특징이 뭔지부터 알아봐야할듯.