### PR TITLE
[Park & Muffin] Refactor code review

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,5 @@ issue #{num}
 
 -- 이부분은 확인 후 지워주세요 --
 제목 컨벤션 -> `[<who>] short-description`
-본문에 이슈번호 태그 -> ex) issue #37
+본문에 이슈번호 태그, 만약 PR과 함께 close 원하면 close #{num}
+-> ex) issue #37, close #37

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules/
+dist/
+# Local Netlify folder
+.netlify

--- a/src/components/Footer/FooterBottom.tsx
+++ b/src/components/Footer/FooterBottom.tsx
@@ -3,7 +3,7 @@ import { Divider, Typography } from '@mui/material';
 import FlexBox from '@components/FlexBox';
 import Copyright from '@components/Footer/Copyright';
 
-const footerNav = [
+const corpItems = [
   '개인정보처리방침',
   '이용약관',
   '한국의 변경된 환불 정책',
@@ -14,11 +14,11 @@ export default function FooterBottom() {
   return (
     <FlexBox component="ul" sx={{ gap: 3, mt: 4 }}>
       <Copyright />
-      {footerNav.map(nav => (
-        <FlexBox key={nav} sx={{ gap: '1rem' }}>
+      {corpItems.map(corpItem => (
+        <FlexBox key={corpItem} sx={{ gap: '1rem' }}>
           <Divider orientation="vertical" flexItem />
           <li>
-            <Typography>{nav}</Typography>
+            <Typography>{corpItem}</Typography>
           </li>
         </FlexBox>
       ))}

--- a/src/components/Footer/FooterItems.tsx
+++ b/src/components/Footer/FooterItems.tsx
@@ -2,17 +2,17 @@ import { Grid, Typography } from '@mui/material';
 
 import footerData from '@mocks/footer';
 
-const { data } = footerData;
+const { data: footerItems } = footerData;
 
 export default function FooterItems() {
   return (
     <Grid container columnSpacing={2}>
-      {data.map(item => (
-        <Grid key={item.mainTitle} item xs={3}>
+      {footerItems.map(({ mainTitle, subTitles }) => (
+        <Grid key={mainTitle} item xs={3}>
           <Typography component="h6" variant="footer1" sx={{ fontWeight: 900 }}>
-            {item.mainTitle}
+            {mainTitle}
           </Typography>
-          {item.subs.map(subItem => (
+          {subTitles.map(subItem => (
             <Typography
               key={subItem.title}
               component="p"

--- a/src/contexts/HeaderProvider.tsx
+++ b/src/contexts/HeaderProvider.tsx
@@ -13,6 +13,11 @@ type Action =
 
 type HeaderDispatch = Dispatch<Action>;
 
+const initHeaderState: State = {
+  menuType: 'none',
+  isFocus: false,
+};
+
 const HeaderStateContext = createContext<State | null>(null);
 const HeaderDispatchContext = createContext<HeaderDispatch | null>(null);
 
@@ -24,20 +29,14 @@ function reducer(state: State, action: Action): State {
         isFocus: !state.isFocus,
       };
     case 'BODY_CLICK':
-      return {
-        menuType: 'none',
-        isFocus: false,
-      };
+      return { ...initHeaderState };
     default:
       throw new Error('Unhandled action');
   }
 }
 
 export function HeaderProvider({ children }: { children: React.ReactNode }) {
-  const [state, dispatch] = useReducer(reducer, {
-    isFocus: false,
-    menuType: 'none',
-  });
+  const [state, dispatch] = useReducer(reducer, initHeaderState);
 
   return (
     <HeaderStateContext.Provider value={state}>

--- a/src/hooks/useScroll.tsx
+++ b/src/hooks/useScroll.tsx
@@ -1,4 +1,4 @@
-import debounce from 'lodash/debounce';
+import throttle from 'lodash/throttle';
 import { useState, useEffect } from 'react';
 
 export function useScroll() {
@@ -8,10 +8,10 @@ export function useScroll() {
     setScrollY(window.pageYOffset);
   };
 
-  const delay = 100;
+  const delay = 500;
 
   useEffect(() => {
-    window.addEventListener('scroll', debounce(listener, delay));
+    window.addEventListener('scroll', throttle(listener, delay));
     return () => window.removeEventListener('scroll', listener);
   }, []);
 

--- a/src/mocks/footer.js
+++ b/src/mocks/footer.js
@@ -2,7 +2,7 @@ const footer = {
   data: [
     {
       mainTitle: '소개',
-      subs: [
+      subTitles: [
         {
           title: '이용방법',
         },
@@ -31,7 +31,7 @@ const footer = {
     },
     {
       mainTitle: '커뮤니티',
-      subs: [
+      subTitles: [
         {
           title: '다양성 및 소속감',
         },
@@ -51,7 +51,7 @@ const footer = {
     },
     {
       mainTitle: '호스팅하기',
-      subs: [
+      subTitles: [
         {
           title: '호스팅하기',
         },
@@ -80,7 +80,7 @@ const footer = {
     },
     {
       mainTitle: '지원',
-      subs: [
+      subTitles: [
         {
           title: '코로나19 대응',
         },


### PR DESCRIPTION
close #40 

- item 이라고 쓰여지는 항목의 명확한 이름 넣기, map 내부에서 distructuring 으로 사용하기
- footerNav -> corpItems 로 이름 변경
- scroll 관련 로직 debounce -> throttle 로 변경
- header provider 에서 자주 사용되는 state (init state) 를 따로 빼내어 사용
- 배포 관련(netlify, dist) ignore 추가, PR template 오타 수정