### PR TITLE
[Park] header modal base 작성

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,14 +9,20 @@ module.exports = {
       typescript: {},
     },
   },
-  extends: ['airbnb', 'airbnb/hooks', 'prettier'],
+  extends: [
+    'airbnb',
+    'airbnb/hooks',
+    'prettier',
+    'plugin:@typescript-eslint/recommended',
+  ],
   parser: '@typescript-eslint/parser',
   rules: {
     'react/require-default-props': 'off',
     // 화살표 함수의 파라미터가 하나일때 괄호 생략
     'arrow-parens': ['warn', 'as-needed'],
     // 사용하지 않는 변수가 있을때 빌드에러가 나던 규칙 해제
-    'no-unused-vars': 'warn',
+    // typescript-eslint 를 extends 에 추가하여 ts 규칙에 어긋나는 것만 오류로
+    'no-unused-vars': 'off',
     // export const 문을 쓸때 에러를 내는 규칙 해제
     'import/prefer-default-export': 'off',
     // hooks의 의존성배열이 충분하지 않을때 강제로 의존성을 추가하는 규칙을 완화

--- a/src/components/Header/BigSearchBar/BigMenu.tsx
+++ b/src/components/Header/BigSearchBar/BigMenu.tsx
@@ -14,13 +14,19 @@ interface Props {
   menu: IBigMenu;
   width: string;
   isSelectedType: boolean;
+  changeMenuType: (menuType: MenuType) => void;
 }
 
 export default function BigMenu({
-  menu: { title, placeholder },
+  menu: { title, placeholder, menuType },
   width,
   isSelectedType,
+  changeMenuType,
 }: Props) {
+  const handleClickBigMenu = () => {
+    changeMenuType(menuType);
+  };
+
   return (
     <Box
       sx={{
@@ -37,6 +43,7 @@ export default function BigMenu({
           height: '100%',
           width: '100%',
           padding: '0 1.5rem',
+          cursor: 'pointer',
           ...(isSelectedType
             ? {
                 backgroundColor: color.white,
@@ -49,6 +56,7 @@ export default function BigMenu({
                 },
               }),
         }}
+        onClick={handleClickBigMenu}
       >
         <Typography variant="h6">{title}</Typography>
         <Typography variant="input1">{placeholder}</Typography>

--- a/src/components/Header/BigSearchBar/BigMenus.tsx
+++ b/src/components/Header/BigSearchBar/BigMenus.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 
 import BigMenu, { IBigMenu } from '@components/Header/BigSearchBar/BigMenu';
 import { MenuType } from '@components/Header/MiniSearchBar/Menu';
-import { useHeaderState } from '@contexts/HeaderProvider';
+import { useHeaderDispatch, useHeaderState } from '@contexts/HeaderProvider';
 
 const menus: IBigMenu[] = [
-  { menuType: 'schedule', title: '체크인', placeholder: '날짜 입력' },
-  { menuType: 'none', title: '체크아웃', placeholder: '날짜 입력' },
+  { menuType: 'checkin', title: '체크인', placeholder: '날짜 입력' },
+  { menuType: 'checkout', title: '체크아웃', placeholder: '날짜 입력' },
   { menuType: 'price', title: '요금', placeholder: '금액대 설정' },
   { menuType: 'persons', title: '인원', placeholder: '게스트 추가' },
 ];
@@ -16,9 +16,14 @@ const menuWidthsOrder = ['20%', '20%', '30%', '30%'];
 
 export default function BigMenus() {
   const headerState = useHeaderState();
+  const headerDispatch = useHeaderDispatch();
 
   const isSelectedType = (menuType: MenuType) =>
     menuType === headerState.menuType;
+
+  const changeMenuType = (menuType: MenuType) => {
+    headerDispatch({ type: 'CHANGE_MENU_TYPE', menuType });
+  };
 
   return (
     <>
@@ -30,6 +35,7 @@ export default function BigMenus() {
               menu={menu}
               width={menuWidthsOrder[idx]}
               isSelectedType={isSelectedType(menu.menuType)}
+              changeMenuType={changeMenuType}
             />
             {idx + 1 !== menus.length && (
               <Divider orientation="vertical" flexItem />

--- a/src/components/Header/BigSearchBar/Modal/index.tsx
+++ b/src/components/Header/BigSearchBar/Modal/index.tsx
@@ -1,0 +1,42 @@
+import { Paper } from '@mui/material';
+
+import { MenuType } from '@components/Header/MiniSearchBar/Menu';
+import { HeaderState, useHeaderState } from '@contexts/HeaderProvider';
+
+type MenuInfoType = {
+  [key in MenuType]: string;
+};
+
+const menuWidthInfo: MenuInfoType = {
+  checkin: '100%',
+  checkout: '100%',
+  price: '50%',
+  persons: '40%',
+  none: '0%',
+};
+
+const menuHeightInfo: MenuInfoType = {
+  checkin: '30rem',
+  checkout: '30rem',
+  price: '20rem',
+  persons: '20rem',
+  none: '0',
+};
+
+interface ModalProps {
+  // TODO: 나중에 optional 풀기
+  children?: React.ReactNode;
+}
+
+export default function Modal({ children }: ModalProps) {
+  const { menuType }: HeaderState = useHeaderState();
+
+  const width: string = menuWidthInfo[menuType];
+  const height: string = menuHeightInfo[menuType];
+
+  return (
+    <Paper sx={{ position: 'absolute', right: 0, top: '6rem', width, height }}>
+      {children}
+    </Paper>
+  );
+}

--- a/src/components/Header/BigSearchBar/index.tsx
+++ b/src/components/Header/BigSearchBar/index.tsx
@@ -4,6 +4,7 @@ import { Fab } from '@mui/material';
 import { fadeIn } from '@common/keyframes';
 import FlexBox from '@components/FlexBox';
 import BigMenus from '@components/Header/BigSearchBar/BigMenus';
+import Modal from '@components/Header/BigSearchBar/Modal';
 import color from '@constants/color';
 import fontSize from '@constants/fontSize';
 
@@ -12,6 +13,7 @@ export default function BigSearchBar() {
     <FlexBox
       component="article"
       sx={{
+        position: 'relative',
         backgroundColor: color.grey6,
         width: '57.25rem',
         height: '4.75rem',
@@ -37,6 +39,7 @@ export default function BigSearchBar() {
         />
         <span>검색</span>
       </Fab>
+      <Modal />
     </FlexBox>
   );
 }

--- a/src/components/Header/MiniSearchBar/Menu.tsx
+++ b/src/components/Header/MiniSearchBar/Menu.tsx
@@ -2,7 +2,7 @@ import { Typography } from '@mui/material';
 
 import { useHeaderDispatch } from '@contexts/HeaderProvider';
 
-export type MenuType = 'persons' | 'schedule' | 'price' | 'none';
+export type MenuType = 'persons' | 'checkin' | 'checkout' | 'price' | 'none';
 
 export interface IMenu {
   menuType: MenuType;

--- a/src/components/Header/MiniSearchBar/Menus.tsx
+++ b/src/components/Header/MiniSearchBar/Menus.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Menu, { IMenu } from '@components/Header/MiniSearchBar/Menu';
 
 const menus: IMenu[] = [
-  { menuType: 'schedule', title: '일정 입력' },
+  { menuType: 'checkin', title: '일정 입력' },
   { menuType: 'price', title: '금액대 입력' },
   { menuType: 'persons', title: '인원 입력' },
 ];

--- a/src/contexts/HeaderProvider.tsx
+++ b/src/contexts/HeaderProvider.tsx
@@ -2,26 +2,27 @@ import React, { useReducer, useContext, createContext, Dispatch } from 'react';
 
 import { MenuType } from '@components/Header/MiniSearchBar/Menu';
 
-type State = {
+export interface HeaderState {
   menuType: MenuType;
   isFocus: boolean;
-};
+}
 
 type Action =
   | { type: 'TOGGLE_FOCUS'; menuType: MenuType }
+  | { type: 'CHANGE_MENU_TYPE'; menuType: MenuType }
   | { type: 'BODY_CLICK' };
 
 type HeaderDispatch = Dispatch<Action>;
 
-const initHeaderState: State = {
+const initHeaderState: HeaderState = {
   menuType: 'none',
   isFocus: false,
 };
 
-const HeaderStateContext = createContext<State | null>(null);
+const HeaderStateContext = createContext<HeaderState | null>(null);
 const HeaderDispatchContext = createContext<HeaderDispatch | null>(null);
 
-function reducer(state: State, action: Action): State {
+function reducer(state: HeaderState, action: Action): HeaderState {
   switch (action.type) {
     case 'TOGGLE_FOCUS':
       return {
@@ -30,6 +31,11 @@ function reducer(state: State, action: Action): State {
       };
     case 'BODY_CLICK':
       return { ...initHeaderState };
+    case 'CHANGE_MENU_TYPE':
+      return {
+        ...state,
+        menuType: action.menuType,
+      };
     default:
       throw new Error('Unhandled action');
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 
 const HtmlWebpackPlugin = require('html-webpack-plugin');


### PR DESCRIPTION
issue #42, close #42 

- ESLint + TypeScript 관련
  - Object 의 key 로 union type 으로 설정했던 것(MenuType) 을 쓰려고 하니 `TS 7053` 오류가 생겼습니다.
  - 이를 해결하기 위해 `[key in MenuType]: string` 이라는 것을 사용했습니다.
  - 그런데 key 가 un-used-vars ESLint 에 걸리더라구요, 이에 대해서 찾아보니 ts 를 위한 un-used-vars 를 따로 사용하고 있는 것 같길래 기존의 un-used-vars 는 off 하고 extends 에 typescript-eslint 를 추가하였습니다.
  
- type 수정 `schedule` -> `checkin` , `checkout`
  - 현재 `selected` 되었는 지를 menu type 을 통해 확인하고 있었는데, 체크인과 체크아웃이 동일한 menu type 을 사용하면 둘 다 selected 되었다고 판단하기 때문에 임시로 'none' 으로 사용하고 있었습니다, 그런데 체크아웃을 눌렀을 때에도 캘린더 모달이 나와야 하기 때문에 다시 `checkin`, `checkout` 으로 MenuType 을 변경하여 사용하도록 하였습니다.
  
- type -> interface
  - type 과 interface 중 어떤 것을 사용할 것인지 제 스스로의 기준은 
    - type -> `union type` or `tuple type` ex) type a = 'b' | 'c' , type d = [string, number]
    - 그 외 interface
  - 인데, 그 기준에 벗어난 지정이라고 생각해서 menu type 에 대한 것을 interface 로 바꾸었습니다.
  - 머핀은 스스로 정하신 기준이 있나요? 있다면 얘기해보고 동일하게 컨벤션으로 정해서 사용하는게 좋을 것 같다는 생각이 들었습니다.
  
### TODO
- modal children
  - modal 내부에 어떤 컴포넌트를 사용할 건지 children 으로 넘긴다고 말씀드렸는데 현재는 만들어진 컴포넌트가 없기 때문에 optional 하게 타입을 확인하도록 했어요, 안그러면 오류가 나더라구요, 저희가 사용할 component 를 props 로 넘겨준 이후 해당 optional 연산자는 지워주는게 좋을 것 같습니다.

