### PR TITLE
[Park] SearchResultPage layout + kakao map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules/
 dist/
 # Local Netlify folder
 .netlify
+
+# environment
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@typescript-eslint/eslint-plugin": "^5.26.0",
         "@typescript-eslint/parser": "^5.26.0",
         "babel-loader": "^8.2.5",
+        "dotenv": "^16.0.1",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.5.0",
         "eslint-import-resolver-typescript": "^2.7.1",
@@ -4251,6 +4252,15 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/duplexer": {
@@ -12040,6 +12050,12 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "dotenv": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
+      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
+      "dev": true
     },
     "duplexer": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@typescript-eslint/eslint-plugin": "^5.26.0",
     "@typescript-eslint/parser": "^5.26.0",
     "babel-loader": "^8.2.5",
+    "dotenv": "^16.0.1",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-typescript": "^2.7.1",

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,10 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+    <script
+      type="text/javascript"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=<%= htmlWebpackPlugin.options.env.KAKAO_MAP_KEY%>&autoload=false"
+    ></script>
     <div id="root"></div>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Layout from '@components/Layout';
 import color from '@constants/color';
 import { HeaderProvider, useHeaderState } from '@contexts/HeaderProvider';
 import MainPage from '@pages/MainPage';
+import SearchResultPage from '@pages/SearchResultPage';
 
 function MyGlobalStyles() {
   const { isFocus } = useHeaderState();
@@ -49,6 +50,7 @@ export default function App() {
             <Routes>
               <Route path="/" element={<Layout />}>
                 <Route index element={<MainPage />} />
+                <Route path="rooms" element={<SearchResultPage />} />
               </Route>
             </Routes>
           </Router>

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -1,0 +1,11 @@
+export const getGeoLocation = () =>
+  new Promise((resolve, reject) => {
+    navigator.geolocation.getCurrentPosition(
+      position => {
+        resolve(position);
+      },
+      error => {
+        reject(error.message);
+      },
+    );
+  });

--- a/src/components/Header/BigSearchBar/index.tsx
+++ b/src/components/Header/BigSearchBar/index.tsx
@@ -1,6 +1,7 @@
 import SearchIcon from '@mui/icons-material/Search';
 import { Fab } from '@mui/material';
 import { Calendar, CalendarProvider } from 'react-carousel-calendar';
+import { useNavigate } from 'react-router-dom';
 
 import Chart from '@components/Chart';
 import FlexBox from '@components/FlexBox';
@@ -16,6 +17,7 @@ import { PersonProvider } from '@contexts/PersonProvider';
 import { PriceProvider } from '@contexts/PriceProvider';
 
 export default function BigSearchBar() {
+  const navigate = useNavigate();
   const headerDispatch = useHeaderDispatch();
   const headerState = useHeaderState();
 
@@ -79,6 +81,10 @@ export default function BigSearchBar() {
               variant="extended"
               color="primary"
               sx={{ width: '6rem', mr: '1rem', position: 'absolute', right: 0 }}
+              onClick={() => {
+                headerDispatch({ type: 'BODY_CLICK' });
+                navigate('/rooms');
+              }}
             >
               <SearchIcon
                 sx={{

--- a/src/components/Header/Logo.tsx
+++ b/src/components/Header/Logo.tsx
@@ -1,9 +1,20 @@
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
 
 const Title = styled.span`
   font-size: 2rem;
   font-weight: 900;
+  cursor: pointer;
 `;
 export default function Logo() {
-  return <Title>Logo</Title>;
+  const navigate = useNavigate();
+  return (
+    <Title
+      onClick={() => {
+        navigate('/');
+      }}
+    >
+      Logo
+    </Title>
+  );
 }

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -42,6 +42,7 @@ export default function Header() {
           top: 0,
           left: 0,
           right: 0,
+          zIndex: 3,
         }}
       >
         <Container maxWidth="lg">

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,5 @@
 import { Outlet } from 'react-router-dom';
 
-import Footer from '@components/Footer';
 import Header from '@components/Header';
 
 export default function Layout() {
@@ -8,7 +7,6 @@ export default function Layout() {
     <>
       <Header />
       <Outlet />
-      <Footer />
     </>
   );
 }

--- a/src/components/SearchResult/SkeletonRoom.tsx
+++ b/src/components/SearchResult/SkeletonRoom.tsx
@@ -1,0 +1,34 @@
+import { Box, Skeleton } from '@mui/material';
+
+const wrapperStyle = {
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  height: '15rem',
+  gap: '1rem',
+};
+
+const imageStyle = {
+  width: '100%',
+  height: '100%',
+};
+
+export default function SkeletonRoom() {
+  return (
+    <Box sx={wrapperStyle}>
+      <Box sx={imageStyle}>
+        <Skeleton
+          sx={{ borderRadius: '1rem' }}
+          variant="rectangular"
+          width="100%"
+          height="100%"
+        />
+      </Box>
+      <Box>
+        <Skeleton variant="text" width="30%" />
+        <Skeleton variant="text" width="80%" />
+        <Skeleton variant="text" width="60%" />
+        <Skeleton variant="text" width="60%" />
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/SearchResult/SkeletonRooms.tsx
+++ b/src/components/SearchResult/SkeletonRooms.tsx
@@ -1,0 +1,21 @@
+import { Box, Skeleton, Stack, Typography } from '@mui/material';
+
+import SkeletonRoom from '@components/SearchResult/SkeletonRoom';
+
+export default function SkeletonRooms() {
+  return (
+    <Stack spacing={2} sx={{ padding: '1rem' }}>
+      <Box>
+        <Typography variant="h4">
+          <Skeleton variant="text" />
+        </Typography>
+        <Typography variant="h2">
+          <Skeleton variant="text" />
+        </Typography>
+      </Box>
+      {new Array(3).fill(0).map((_, idx) => (
+        <SkeletonRoom key={`skeleton-${idx + 1}`} />
+      ))}
+    </Stack>
+  );
+}

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,21 +1,25 @@
 import { Box, Container } from '@mui/material';
 
 import Background from '@components/Background';
+import Footer from '@components/Footer';
 import AnyWhereBox from '@components/Main/AnyWhereBox';
 import NearByBox from '@components/Main/NearByBox';
 
 export default function MainPage() {
   return (
-    <Container maxWidth="lg">
-      <Box sx={{ margin: '0 auto' }}>
-        <Background />
-        <Box sx={{ marginBottom: '5rem' }}>
-          <NearByBox />
+    <>
+      <Container maxWidth="lg">
+        <Box sx={{ margin: '0 auto' }}>
+          <Background />
+          <Box sx={{ marginBottom: '5rem' }}>
+            <NearByBox />
+          </Box>
+          <Box sx={{ marginBottom: '5rem' }}>
+            <AnyWhereBox />
+          </Box>
         </Box>
-        <Box sx={{ marginBottom: '5rem' }}>
-          <AnyWhereBox />
-        </Box>
-      </Box>
-    </Container>
+      </Container>
+      <Footer />
+    </>
   );
 }

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -1,6 +1,10 @@
 import { Box, Skeleton } from '@mui/material';
+import { useEffect, useRef, useState } from 'react';
 
+import { getGeoLocation } from '@common/util';
 import SkeletonRooms from '@components/SearchResult/SkeletonRooms';
+
+const { kakao } = window;
 
 const wrapperStyle = {
   display: 'grid',
@@ -9,12 +13,54 @@ const wrapperStyle = {
   marginTop: '5.875rem',
 };
 
+const delay = (ms: number) =>
+  new Promise(resolve => {
+    setTimeout(() => {
+      resolve(true);
+    }, ms);
+  });
+
 export default function SearchResultPage() {
+  const mapRef = useRef();
+  const [isLoading, setIsLoading] = useState(false);
+  const [userGeolocation, setUserGeoLocation] = useState([]);
+
+  useEffect(() => {
+    const getUserGeoLocation = async () => {
+      if (!userGeolocation.length) {
+        const {
+          coords: { latitude, longitude },
+        } = await getGeoLocation();
+        setUserGeoLocation([latitude, longitude]);
+      }
+    };
+    getUserGeoLocation();
+  }, []);
+
+  useEffect(() => {
+    const fetchMap = async () => {
+      setIsLoading(true);
+      await delay(2000); // 의도적으로 로딩 보여지게 함
+      kakao.maps.load(() => {
+        const [userLatitude, userLongitude] = userGeolocation;
+        const mapOptions = {
+          center: new kakao.maps.LatLng(userLatitude, userLongitude),
+          level: 3,
+        };
+        const map = new kakao.maps.Map(mapRef.current, mapOptions);
+      });
+      setIsLoading(false);
+    };
+    if (userGeolocation.length) {
+      fetchMap();
+    }
+  }, [userGeolocation]);
+
   return (
     <Box sx={wrapperStyle}>
       <SkeletonRooms />
-      <Box>
-        <Skeleton variant="rectangular" height="100%" />
+      <Box ref={mapRef}>
+        {isLoading && <Skeleton variant="rectangular" height="100%" />}
       </Box>
     </Box>
   );

--- a/src/pages/SearchResultPage.tsx
+++ b/src/pages/SearchResultPage.tsx
@@ -1,0 +1,21 @@
+import { Box, Skeleton } from '@mui/material';
+
+import SkeletonRooms from '@components/SearchResult/SkeletonRooms';
+
+const wrapperStyle = {
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  height: '100vh',
+  marginTop: '5.875rem',
+};
+
+export default function SearchResultPage() {
+  return (
+    <Box sx={wrapperStyle}>
+      <SkeletonRooms />
+      <Box>
+        <Skeleton variant="rectangular" height="100%" />
+      </Box>
+    </Box>
+  );
+}

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,7 @@
+export {};
+
+declare global {
+  interface Window {
+    kakao: any;
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,15 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 
+const dotenv = require('dotenv');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const webpack = require('webpack');
+
+dotenv.config();
 
 const mode = process.env.NODE_ENV || 'development';
+const { KAKAO_MAP_KEY } = process.env;
+
 const PORT = 3000;
 
 module.exports = {
@@ -49,6 +55,10 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       template: './public/index.html',
+      env: process.env,
+    }),
+    new webpack.EnvironmentPlugin({
+      KAKAO_MAP_KEY,
     }),
   ],
   stats: 'errors-only',


### PR DESCRIPTION
close #59 
close #61

- Layout
  - grid template columns 로 50% 50% 가 되게 하였습니다. (1fr 1fr)
  - 현재 Skeleton 으로 Layout 을 잡은 상태입니다.
- env
  - map API KEY 는 Private 하게 관리되어야 할 것 같아 추가되었습니다.
  - 분명히 CRA 에서 쓰는 것 처럼 `%PUBLIC_URL%` 이렇게 html 에서 쓸 수 있을텐데 아직 구글링에 한계를 느껴서 `dotenv` 와 `htmlWebpackPlugin` 을 사용하는 식으로 사용했습니다.

- Footer 부분은 MainPage 에서만 사용되어서 Layout 에서 옮겼습니다.

- kakao script 를 html 에 추가하면 전역에 kakao 라는 property 가 추가되는 형태인데, 그래서 `global.d.ts` 로 타입을 선언하였습니다. 이상한건 `export {}` 를 붙이지 않으면 계속 잡지 못했다는 건데 정확한 이유는 잘 모르겠습니다. [링크](https://bobbyhadz.com/blog/typescript-property-does-not-exist-on-type-window)

- autoload query 를 추가해서 SearchResultPage 를 사용할 때 맵을 불러오는 식으로 사용하였습니다.