### PR TITLE
[Muffin] 차트 슬라이드 에러 수정

### DIFF
--- a/src/components/Chart/Graph.tsx
+++ b/src/components/Chart/Graph.tsx
@@ -164,7 +164,9 @@ export default function Graph({ priceState, accommodationData }: GraphProps) {
     }
 
     const minPrice = Math.floor(percentage * sliderNewValue[0]);
-    const maxPrice = Math.floor(percentage * sliderNewValue[1]);
+    let maxPrice = Math.floor(percentage * sliderNewValue[1]);
+
+    if (minPrice === maxPrice) maxPrice += percentage * sliderInterval;
 
     if (activeThumb === 0) {
       setSliderValue([

--- a/src/components/Chart/index.tsx
+++ b/src/components/Chart/index.tsx
@@ -74,11 +74,15 @@ export default function Chart() {
       <FlexBox sx={{ position: 'relative' }} fd="column">
         <Typography sx={{ fontWeight: 700 }}>가격 범위</Typography>
         <Title priceState={priceState} getAveragePrice={getAveragePrice} />
-        {isCheckDate() && (
+        {isCheckDate() ? (
           <Graph
             priceState={priceState}
             accommodationData={accommodationData}
           />
+        ) : (
+          <Typography variant="input2" sx={{ textAlign: 'center' }}>
+            체크인, 체크아웃 날짜를 먼저 선택해주세요.
+          </Typography>
         )}
       </FlexBox>
     </FlexBox>

--- a/src/components/Header/BigSearchBar/BigMenu.tsx
+++ b/src/components/Header/BigSearchBar/BigMenu.tsx
@@ -73,8 +73,22 @@ export default function BigMenu({
   const handleClickCloseBtn = () => {
     if (menuType === 'checkin') {
       calendarDispatch({ type: 'CHECK_IN_DELETE' });
+      priceDispatch({
+        type: 'SET_PRICE',
+        initMinPrice: 0,
+        initMaxPrice: 0,
+        minPrice: 0,
+        maxPrice: 0,
+      });
     } else if (menuType === 'checkout') {
       calendarDispatch({ type: 'CHECK_OUT_DELETE' });
+      priceDispatch({
+        type: 'SET_PRICE',
+        initMinPrice: 0,
+        initMaxPrice: 0,
+        minPrice: 0,
+        maxPrice: 0,
+      });
     } else if (menuType === 'price') {
       calendarDispatch({ type: 'CHECK_IN_DELETE' });
       calendarDispatch({ type: 'CHECK_OUT_DELETE' });

--- a/src/components/Header/BigSearchBar/BigMenu.tsx
+++ b/src/components/Header/BigSearchBar/BigMenu.tsx
@@ -74,30 +74,18 @@ export default function BigMenu({
     if (menuType === 'checkin') {
       calendarDispatch({ type: 'CHECK_IN_DELETE' });
       priceDispatch({
-        type: 'SET_PRICE',
-        initMinPrice: 0,
-        initMaxPrice: 0,
-        minPrice: 0,
-        maxPrice: 0,
+        type: 'SET_INIT_PRICE',
       });
     } else if (menuType === 'checkout') {
       calendarDispatch({ type: 'CHECK_OUT_DELETE' });
       priceDispatch({
-        type: 'SET_PRICE',
-        initMinPrice: 0,
-        initMaxPrice: 0,
-        minPrice: 0,
-        maxPrice: 0,
+        type: 'SET_INIT_PRICE',
       });
     } else if (menuType === 'price') {
       calendarDispatch({ type: 'CHECK_IN_DELETE' });
       calendarDispatch({ type: 'CHECK_OUT_DELETE' });
       priceDispatch({
-        type: 'SET_PRICE',
-        initMinPrice: 0,
-        initMaxPrice: 0,
-        minPrice: 0,
-        maxPrice: 0,
+        type: 'SET_INIT_PRICE',
       });
     } else if (menuType === 'persons') {
       personDispatch({ type: 'SET_ZERO_PERSONS' });

--- a/src/contexts/PriceProvider.tsx
+++ b/src/contexts/PriceProvider.tsx
@@ -8,6 +8,7 @@ export interface PriceState {
 }
 
 type Action =
+  | { type: 'SET_INIT_PRICE' }
   | { type: 'MIN_PRICE'; minPrice: number; maxPrice: number }
   | { type: 'MAX_PRICE'; minPrice: number; maxPrice: number }
   | {
@@ -32,6 +33,13 @@ const PriceDispatchContext = createContext<PriceDispatch | null>(null);
 
 function reducer(state: PriceState, action: Action): PriceState {
   switch (action.type) {
+    case 'SET_INIT_PRICE':
+      return {
+        initMinPrice: 0,
+        initMaxPrice: 0,
+        minPrice: 0,
+        maxPrice: 0,
+      };
     case 'SET_PRICE':
       return {
         ...state,


### PR DESCRIPTION
close #71
close #73

1. 날짜 선택 미선택 시 차트 모달에 안내 메시지 출력
2. 빅서치바 날짜 인풋에서 x버튼 클릭 시에도 price 값 리셋
3. 슬라이드를 움직이면서 두 min, max의 가격이 같아진다면 if절로 무조건 max값에는 기존의 슬라이드가 겹치지 않도록 설정한 sliderInterval의 값과 백분율 percentage를 곱해준다.

생각보다 슬라이더 겹치는 부분은 쉽게 해결했는데 혹시나 차트 관련하여 다른  문제가 발생하면 다시 이슈 만들도록 할게여~