### PR TITLE
[Muffin] modal창을 열었을때 Header 밀리는 현상

### DIFF
--- a/src/components/SearchResult/RoomModal.tsx
+++ b/src/components/SearchResult/RoomModal.tsx
@@ -35,7 +35,7 @@ export default function RoomModal({
   roomDetailData,
 }: RoomModalProps) {
   return (
-    <Modal open={open} onClose={() => setOpen(false)}>
+    <Modal open={open} onClose={() => setOpen(false)} disableScrollLock>
       <FlexBox sx={modalStyle} fd="column">
         <Box sx={{ marginBottom: '1.5rem' }}>
           <FlexBox jc="space-between">


### PR DESCRIPTION
close #74 

Material UI 에서 Modal 또는 Dialog 컴포넌트를 가져다 사용시 
disableScrollLock(스크롤이 안되게 하는 속성)속성이 기본 default가 false인데 false일 시 body태그에 padding-right 값이 15가 먹히도록 되어있네요..

그래서 모달창이 열려도 스크롤이 되도록 우선 disableScrollLock 속성을 true로 설정해서 우선 해결했어요~
이런게 라이브러리의 안좋은점이랄까요..
